### PR TITLE
fix: clean tracking query params client-side

### DIFF
--- a/lib/queryParams.spec.ts
+++ b/lib/queryParams.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { FUNCTIONAL_QUERY_PARAMS, getCleanedTrackingUrl, STRIPPABLE_QUERY_PARAM_SET } from './queryParams'
+
+describe('getCleanedTrackingUrl', () => {
+  it('removes known tracking params and preserves functional params, unknown params, path, and hash', () => {
+    const url = new URL('https://example.com/articles?utm_source=newsletter&category=tech&foo=bar&gclid=123#post')
+
+    expect(getCleanedTrackingUrl(url)).toBe('/articles?category=tech&foo=bar#post')
+  })
+
+  it('does nothing when no tracking params are present', () => {
+    const url = new URL('https://example.com/art?tag=travel&foo=bar#gallery')
+
+    expect(getCleanedTrackingUrl(url)).toBeNull()
+  })
+
+  it('keeps expected functional params out of the tracking strip list', () => {
+    FUNCTIONAL_QUERY_PARAMS.forEach((param) => {
+      expect(STRIPPABLE_QUERY_PARAM_SET.has(param)).toBe(false)
+    })
+  })
+})

--- a/lib/queryParams.ts
+++ b/lib/queryParams.ts
@@ -1,0 +1,36 @@
+// Only add known marketing/tracking params here. Functional params must stay out of this list.
+export const STRIPPABLE_QUERY_PARAMS = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+  'utm_id',
+  'gclid',
+  'fbclid',
+  'mc_cid',
+  'mc_eid',
+] as const
+
+export const STRIPPABLE_QUERY_PARAM_SET = new Set<string>(STRIPPABLE_QUERY_PARAMS)
+
+// Params with app behavior live here so future contributors keep them separate from tracking params.
+export const FUNCTIONAL_QUERY_PARAMS = new Set(['category', 'tag'])
+
+export const getCleanedTrackingUrl = (url: URL) => {
+  const cleanedUrl = new URL(url)
+  let removedTrackingParam = false
+
+  STRIPPABLE_QUERY_PARAM_SET.forEach((param) => {
+    if (cleanedUrl.searchParams.has(param)) {
+      cleanedUrl.searchParams.delete(param)
+      removedTrackingParam = true
+    }
+  })
+
+  if (!removedTrackingParam) {
+    return null
+  }
+
+  return `${cleanedUrl.pathname}${cleanedUrl.search}${cleanedUrl.hash}`
+}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -2,6 +2,7 @@ import type { DocumentContext } from 'next/document'
 import Document, { Head, Html, Main, NextScript } from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
 import { BASE_URL, X_HANDLE } from '../lib/constants'
+import { STRIPPABLE_QUERY_PARAMS } from '../lib/queryParams'
 
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {
@@ -65,6 +66,39 @@ class MyDocument extends Document {
         <body>
           <Main />
           <NextScript />
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+                (() => {
+                  const cleanupTrackingParams = () => {
+                    const strippableParams = ${JSON.stringify(STRIPPABLE_QUERY_PARAMS)}
+                    const url = new URL(window.location.href)
+                    let removedTrackingParam = false
+
+                    strippableParams.forEach((param) => {
+                      if (url.searchParams.has(param)) {
+                        url.searchParams.delete(param)
+                        removedTrackingParam = true
+                      }
+                    })
+
+                    if (removedTrackingParam) {
+                      window.history.replaceState(window.history.state, '', url.pathname + url.search + url.hash)
+                    }
+                  }
+
+                  const scheduleCleanup = () => window.setTimeout(cleanupTrackingParams, 2000)
+
+                  if (document.readyState === 'complete') {
+                    scheduleCleanup()
+                  } else {
+                    window.addEventListener('load', scheduleCleanup, { once: true })
+                  }
+                })()
+              `,
+            }}
+            id="cleanup-tracking-query-params"
+          />
         </body>
       </Html>
     )


### PR DESCRIPTION
## Summary
- add a single source of truth for known tracking query params and separate functional params
- add a document-level client cleanup script that preserves the initial landing URL, then strips known tracking params with `history.replaceState`
- cover URL cleanup behavior with focused Vitest tests

## Validation
- `npm test -- lib/queryParams.spec.ts --run`
- `npm run lint`
- `npm run lint:css`
- `npx oxfmt --check lib/queryParams.ts lib/queryParams.spec.ts pages/_document.tsx`
- Browser check: `/art?utm_source=newsletter&utm_content=hero&tag=travel&foo=bar&fbclid=abc#gallery` initially loads with tracking params, then cleans to `/art?tag=travel&foo=bar#gallery`

## Known issue
- `npm run tsc` is currently blocked by an existing unrelated error: `pages/contact.tsx(1,21): error TS2307: Cannot find module 'emailjs-com' or its corresponding type declarations.`