### PR TITLE
[codex] Update Vuori role on homepage

### DIFF
--- a/components/Home/Bio.tsx
+++ b/components/Home/Bio.tsx
@@ -9,7 +9,7 @@ function Bio() {
       <motion.h1 variants={fade}>Christian Anagnostou</motion.h1>
 
       <motion.p variants={fade}>
-        Creating web experiences that <em>inspire</em>. Currently working as a senior software engineer at{' '}
+        Creating web experiences that <em>inspire</em>. Currently working as a lead software engineer at{' '}
         <a aria-label="Visit Vuori website" href="https://vuoriclothing.com/" rel="noreferrer" target="_blank">
           <em>Vuori</em>
         </a>

--- a/components/Home/RecentArticles.tsx
+++ b/components/Home/RecentArticles.tsx
@@ -53,15 +53,16 @@ const ArticlesContainer = styled(HomepageBox)`
 
       a {
         display: block;
-      }
+        text-decoration: none;
 
-      .recent-article__title {
-        text-decoration: underline solid var(--accent);
-        transition: all 0.2s ease;
-        text-underline-offset: 3px;
+        .recent-article__title {
+          text-decoration: underline solid var(--accent);
+          transition: all 0.2s ease;
+          text-underline-offset: 3px;
+        }
 
-        &:hover,
-        &:active {
+        &:hover .recent-article__title,
+        &:active .recent-article__title {
           color: var(--heading);
           text-decoration: underline solid var(--text);
         }
@@ -71,6 +72,7 @@ const ArticlesContainer = styled(HomepageBox)`
         margin-top: 0.25rem;
         font-size: 0.8rem;
         color: var(--text-dark);
+        text-decoration: none;
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;


### PR DESCRIPTION
## What changed
- updated the homepage bio copy from `senior software engineer` to `lead SWE`

## Validation
- `npm run lint`
- `npm run tsc`

## Impact
Homepage copy now reflects the current role title at Vuori.