### PR TITLE
feat: show tooltips for narrow Gantt bars

### DIFF
--- a/components/Lab/gantt/ItemBar/index.tsx
+++ b/components/Lab/gantt/ItemBar/index.tsx
@@ -2,7 +2,9 @@ import dayjs from 'dayjs'
 import type { ItemProps } from '..'
 import { RowHeight } from '..'
 import { getDayDiff } from '../utils'
-import { Bar, BarLabel, BarWrap, EndLabel, ItemBarContainer, StartLabel } from './styles'
+import { Bar, BarLabel, BarWrap, EndLabel, ItemBarContainer, StartLabel, Tooltip } from './styles'
+
+const MIN_INLINE_LABEL_WIDTH = 100
 
 interface RenderItemBarProps {
   item: ItemProps
@@ -23,23 +25,26 @@ const ItemBar = (props: RenderItemBarProps) => {
   const minWidth = dateWidth / 3
   const barWidth = daysBetween * dateWidth
   const startsAndEndsToday = dayjs(startDate).isSame(endDate, 'day') && dayjs(endDate).isSame(dayjs(), 'day')
+  const showTooltip = barWidth <= MIN_INLINE_LABEL_WIDTH
 
   return (
     <>
       <ItemBarContainer
         className="gantt-bar"
         data-item-id={item.id}
-        height={RowHeight}
+        $height={RowHeight}
         onMouseEnter={() => handleRowMouseOver(item.id)}
       >
-        <BarWrap rightMargin={dateWidth * 7}>
+        <BarWrap $rightMargin={dateWidth * 7}>
           <Bar
-            backgroundColor={item.barColor || '#3350E8'}
-            height={RowHeight / 2}
-            marginLeft={offsetDaysStart * dateWidth - (barWidth || (startsAndEndsToday ? minWidth : 0)) + dateWidth / 2}
-            width={barWidth || minWidth}
+            $backgroundColor={item.barColor || '#3350E8'}
+            $height={RowHeight / 2}
+            $marginLeft={
+              offsetDaysStart * dateWidth - (barWidth || (startsAndEndsToday ? minWidth : 0)) + dateWidth / 2
+            }
+            $width={barWidth || minWidth}
           >
-            {item.barLabel && barWidth > 100 ? <BarLabel>{item.barLabel}</BarLabel> : null}
+            {item.barLabel && (showTooltip ? <Tooltip>{item.barLabel}</Tooltip> : <BarLabel>{item.barLabel}</BarLabel>)}
             <StartLabel>{dayjs(item.startDate).format('MMM D')}</StartLabel>
             <EndLabel>{dayjs(item.endDate).format('MMM D')}</EndLabel>
           </Bar>

--- a/components/Lab/gantt/ItemBar/styles.ts
+++ b/components/Lab/gantt/ItemBar/styles.ts
@@ -1,10 +1,10 @@
 import styled from 'styled-components'
 
-export const ItemBarContainer = styled.div<{ height: number }>`
+export const ItemBarContainer = styled.div<{ $height: number }>`
   display: inline-flex;
   align-items: center;
   width: 100%;
-  height: ${({ height }) => `${height}px`};
+  height: ${({ $height }) => `${$height}px`};
   user-select: none;
 
   &.hovered {
@@ -12,20 +12,20 @@ export const ItemBarContainer = styled.div<{ height: number }>`
   }
 `
 
-export const BarWrap = styled.div<{ rightMargin: number }>`
-  margin-right: ${({ rightMargin }) => `${rightMargin}px`};
+export const BarWrap = styled.div<{ $rightMargin: number }>`
+  margin-right: ${({ $rightMargin }) => `${$rightMargin}px`};
 `
 
-export const Bar = styled.div<{ width: number; height: number; marginLeft: number; backgroundColor: string }>`
+export const Bar = styled.div<{ $width: number; $height: number; $marginLeft: number; $backgroundColor: string }>`
   position: relative;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: ${({ width }) => `${width}px`};
-  height: ${({ height }) => `${height}px`};
-  margin-left: ${({ marginLeft }) => `${marginLeft}px`};
+  width: ${({ $width }) => `${$width}px`};
+  height: ${({ $height }) => `${$height}px`};
+  margin-left: ${({ $marginLeft }) => `${$marginLeft}px`};
   border-radius: 4px;
-  background-color: ${({ backgroundColor }) => backgroundColor};
+  background-color: ${({ $backgroundColor }) => $backgroundColor};
   font-size: 0.65rem;
 `
 
@@ -54,4 +54,36 @@ export const EndLabel = styled.span`
   z-index: 15;
   min-width: max-content;
   opacity: 0.5;
+`
+
+export const Tooltip = styled.span`
+  position: absolute;
+  top: -0.5rem;
+  left: 50%;
+  z-index: 20;
+  padding: 0.25rem 0.5rem;
+  color: var(--text);
+  font-size: 0.65rem;
+  white-space: nowrap;
+  pointer-events: none;
+  background: var(--dark-bg, rgba(30, 30, 30, 0.95));
+  border-radius: 0.25rem;
+  opacity: 0;
+  transform: translate(-50%, -100%);
+  transition: opacity 0.15s;
+
+  ${Bar}:hover & {
+    opacity: 1;
+  }
+
+  &::after {
+    position: absolute;
+    bottom: -3px;
+    left: 50%;
+    border-left: 3px solid transparent;
+    border-right: 3px solid transparent;
+    border-top: 3px solid var(--dark-bg, rgba(30, 30, 30, 0.95));
+    content: '';
+    transform: translateX(-50%);
+  }
 `


### PR DESCRIPTION
## Summary

Preserves Gantt bar labels when a bar is too narrow to display its text inline by showing the label in a lightweight hover tooltip.

## Changes

- Shows labels inline for bars wider than 100px and in a tooltip for narrower bars
- Converts styled-component layout props to transient props so they are not forwarded to the DOM
- Keeps tooltip presentation in the existing ItemBar style module
- Limits the split to the two files required for the feature

## Testing

- `npm run lint`
- `npm run lint:css`
- `npm run format:check`
- `npm test -- --run`
- `npm run build`

## AI-Generated Code

- AI assistance was used to isolate and clean up the tooltip implementation
- All changes were reviewed and validated before commit

## Checklist

- [x] Self-reviewed code
- [x] Tests pass
- [x] Documentation updated where needed